### PR TITLE
#33 - Listar categorias

### DIFF
--- a/apps/domain/entities/category.py
+++ b/apps/domain/entities/category.py
@@ -5,4 +5,4 @@ from dataclasses import dataclass
 class Category:
     id: int
     description: str
-    icon_url: str
+    icon_url: str = None

--- a/apps/domain/interfaces/repositories/category_repository.py
+++ b/apps/domain/interfaces/repositories/category_repository.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+from apps.domain.entities.category import Category
+
+
+class CategoryRepository(ABC):
+    @abstractmethod
+    def list_all(self) -> List[Category]:
+        pass

--- a/apps/domain/usecases/list_categories_use_case.py
+++ b/apps/domain/usecases/list_categories_use_case.py
@@ -1,0 +1,12 @@
+from typing import List
+
+from apps.domain.entities.category import Category
+from apps.domain.interfaces.repositories.category_repository import CategoryRepository
+
+
+class ListCategoriesUseCase:
+    def __init__(self, category_repository: CategoryRepository):
+        self.category_repository = category_repository
+
+    def list_categories(self) -> List[Category]:
+        return self.category_repository.list_all()

--- a/apps/infrastructure/repositories/django_category_repository.py
+++ b/apps/infrastructure/repositories/django_category_repository.py
@@ -1,0 +1,8 @@
+from apps.domain.entities.category import Category
+from apps.domain.interfaces.repositories.category_repository import CategoryRepository
+from apps.infrastructure.models import CategoryModel
+
+
+class DjangoCategoryRepository(CategoryRepository):
+    def list_all(self):
+        return [Category(id=cat.id, description=cat.description) for cat in CategoryModel.objects.all()]

--- a/apps/interface_adapters/api/v1/serializers/category_serializer.py
+++ b/apps/interface_adapters/api/v1/serializers/category_serializer.py
@@ -1,0 +1,14 @@
+from rest_framework import serializers
+
+from apps.domain.entities.category import Category
+
+
+class CategorySerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    description = serializers.CharField()
+
+    def to_entity(self) -> Category:
+        return Category(
+            id=self.validated_data.get("id"),
+            description=self.validated_data.get("description"),
+        )

--- a/apps/interface_adapters/api/v1/urls.py
+++ b/apps/interface_adapters/api/v1/urls.py
@@ -4,6 +4,7 @@ from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from apps.interface_adapters.api.v1.views.create_client_view import CreateClientView
 from apps.interface_adapters.api.v1.views.create_professional_view import CreateProfessionalView
 from apps.interface_adapters.api.v1.views.detail_client_view import DetailClientView
+from apps.interface_adapters.api.v1.views.list_categories_views import ListCategoriesView
 from apps.interface_adapters.api.v1.views.list_portfolios_view import ListPortfoliosView
 from apps.interface_adapters.api.v1.views.manage_portfolio_views import ManagePortfolioViews
 from apps.interface_adapters.api.v1.views.profile_client_view import ProfileClientView
@@ -19,4 +20,5 @@ urlpatterns = [
     path("manage/portfolios/", ManagePortfolioViews.as_view(), name="manage-portfolio"),
     path("portfolios/", ListPortfoliosView.as_view(), name="list-portfolios"),
     path("search/portfolios/", SearchPortfolioView.as_view(), name="search-portfolios"),
+    path("categories/", ListCategoriesView.as_view(), name="list-categories"),
 ]

--- a/apps/interface_adapters/api/v1/views/list_categories_views.py
+++ b/apps/interface_adapters/api/v1/views/list_categories_views.py
@@ -1,0 +1,15 @@
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.domain.usecases.list_categories_use_case import ListCategoriesUseCase
+from apps.infrastructure.repositories.django_category_repository import DjangoCategoryRepository
+from apps.interface_adapters.api.v1.serializers.category_serializer import CategorySerializer
+
+
+class ListCategoriesView(APIView):
+    def get(self, request):
+        use_case = ListCategoriesUseCase(DjangoCategoryRepository())
+        categories = use_case.list_categories()
+        serializer = CategorySerializer(categories, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/tests/api/v1/list_categories_view.py
+++ b/tests/api/v1/list_categories_view.py
@@ -1,0 +1,21 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from apps.infrastructure.models import CategoryModel
+
+
+class ListCategoriesViewTests(APITestCase):
+    def setUp(self):
+        self.api_client = APIClient()
+        self.category1 = CategoryModel.objects.create(description="Categoria 1")
+        self.category2 = CategoryModel.objects.create(description="Categoria 2")
+
+    def test_list_categories_success(self):
+        url = reverse("list-categories")
+        response = self.api_client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        descriptions = [c["description"] for c in response.data]
+        self.assertIn("Categoria 1", descriptions)
+        self.assertIn("Categoria 2", descriptions)

--- a/tests/integration/usecases/test_list_categories_use_case.py
+++ b/tests/integration/usecases/test_list_categories_use_case.py
@@ -1,0 +1,19 @@
+from django.test import TestCase
+
+from apps.domain.usecases.list_categories_use_case import ListCategoriesUseCase
+from apps.infrastructure.models import CategoryModel
+from apps.infrastructure.repositories.django_category_repository import DjangoCategoryRepository
+
+
+class ListCategoriesUseCaseIntegrationTest(TestCase):
+    def setUp(self):
+        self.category1 = CategoryModel.objects.create(description="Categoria 1")
+        self.category2 = CategoryModel.objects.create(description="Categoria 2")
+
+    def test_list_categories_returns_all(self):
+        use_case = ListCategoriesUseCase(DjangoCategoryRepository())
+        categories = use_case.list_categories()
+        descriptions = [c.description for c in categories]
+        self.assertEqual(len(categories), 2)
+        self.assertIn("Categoria 1", descriptions)
+        self.assertIn("Categoria 2", descriptions)

--- a/tests/unit/usecases/test_list_category_use_case.py
+++ b/tests/unit/usecases/test_list_category_use_case.py
@@ -1,0 +1,19 @@
+import unittest
+from unittest.mock import MagicMock
+
+from apps.domain.entities.category import Category
+from apps.domain.usecases.list_categories_use_case import ListCategoriesUseCase
+
+
+class TestListCategoriesUseCase(unittest.TestCase):
+    def test_list_categories_returns_all(self):
+        mock_category_repository = MagicMock()
+        categories = [
+            Category(id=1, description="Categoria 1"),
+            Category(id=2, description="Categoria 2"),
+        ]
+        mock_category_repository.list_all.return_value = categories
+        use_case = ListCategoriesUseCase(mock_category_repository)
+        result = use_case.list_categories()
+        self.assertEqual(result, categories)
+        mock_category_repository.list_all.assert_called_once()


### PR DESCRIPTION
This pull request introduces a new feature to list categories in the application. It includes changes across multiple layers of the architecture, from the domain layer to the API layer, along with corresponding tests to ensure functionality. The most important changes are grouped by theme below.

### Domain Layer Enhancements:
* Added `CategoryRepository` interface to define a contract for category-related data operations. (`apps/domain/interfaces/repositories/category_repository.py`)
* Implemented `ListCategoriesUseCase` to encapsulate the business logic for listing categories. (`apps/domain/usecases/list_categories_use_case.py`)

### Infrastructure Layer Implementation:
* Created `DjangoCategoryRepository` to provide a concrete implementation of `CategoryRepository` using Django ORM. (`apps/infrastructure/repositories/django_category_repository.py`)

### API Layer Integration:
* Added `ListCategoriesView` to expose the category listing functionality via an API endpoint. (`apps/interface_adapters/api/v1/views/list_categories_views.py`)
* Updated `urls.py` to include the new `/categories/` endpoint. (`apps/interface_adapters/api/v1/urls.py`) [[1]](diffhunk://#diff-5f919806e790c298ef7f1ce0c30b8755395eb795e420d331f84ad3ad675faaf1R7) [[2]](diffhunk://#diff-5f919806e790c298ef7f1ce0c30b8755395eb795e420d331f84ad3ad675faaf1R23)

### Testing Coverage:
* Added unit tests for `ListCategoriesUseCase` to verify its behavior with mocked repositories. (`tests/unit/usecases/test_list_category_use_case.py`)
* Created integration tests for `ListCategoriesUseCase` to validate its functionality with the actual repository. (`tests/integration/usecases/test_list_categories_use_case.py`)
* Implemented API tests for `ListCategoriesView` to ensure the endpoint works correctly and returns expected results. (`tests/api/v1/list_categories_view.py`)