### PR TITLE
#37 - Profissional - Listagem de propostas

### DIFF
--- a/apps/domain/interfaces/repositories/proposal_repository.py
+++ b/apps/domain/interfaces/repositories/proposal_repository.py
@@ -7,3 +7,7 @@ class ProposalRepository(ABC):
     @abstractmethod
     def create(self, proposal: Proposal) -> None:
         pass
+
+    @abstractmethod
+    def list_proposals_by_professional(self, professional_id: str):
+        pass

--- a/apps/domain/usecases/list_professional_proposals_use_case.py
+++ b/apps/domain/usecases/list_professional_proposals_use_case.py
@@ -1,0 +1,12 @@
+from apps.domain.interfaces.repositories.professional_repository import ProfessionalRepository
+from apps.domain.interfaces.repositories.proposal_repository import ProposalRepository
+
+
+class ListProfessionalProposalsUseCase:
+    def __init__(self, proposal_repository: ProposalRepository, professional_repository: ProfessionalRepository):
+        self.proposal_repository = proposal_repository
+        self.professional_repository = professional_repository
+
+    def list_all(self, client_id: str):
+        professional = self.professional_repository.get_by_id(client_id)
+        return self.proposal_repository.list_proposals_by_professional(professional.id)

--- a/apps/infrastructure/repositories/django_proposal_repository.py
+++ b/apps/infrastructure/repositories/django_proposal_repository.py
@@ -4,6 +4,25 @@ from apps.infrastructure.models import ProposalModel, ProposalServiceModel
 
 
 class DjangoProposalRepository(ProposalRepository):
+    def list_proposals_by_professional(self, professional_id: str):
+        proposals = list()
+        proposal_models = ProposalModel.objects.filter(professional_id=professional_id)
+
+        for proposal_model in proposal_models:
+            services = [service.service for service in proposal_model.proposal_services.all()]
+            proposal = Proposal(
+                id=proposal_model.id,
+                confirmed=proposal_model.confirmed,
+                value=proposal_model.value,
+                scheduled_datetime=proposal_model.scheduled_datetime,
+                client=proposal_model.client,
+                professional=proposal_model.professional,
+                services=services,
+            )
+            proposals.append(proposal)
+
+        return proposals
+
     def create(self, proposal: Proposal) -> Proposal:
         proposal_model = ProposalModel.objects.create(
             confirmed=proposal.confirmed,

--- a/apps/interface_adapters/api/v1/serializers/proposal_serializer.py
+++ b/apps/interface_adapters/api/v1/serializers/proposal_serializer.py
@@ -4,6 +4,26 @@ from apps.domain.entities.professional import Client, Professional
 from apps.domain.entities.proposal import Proposal
 
 
+class SimpleClientSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    first_name = serializers.CharField(max_length=100, read_only=True)
+    last_name = serializers.CharField(max_length=100, read_only=True)
+
+
+class SimplesServiceSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    description = serializers.CharField(max_length=255, read_only=True)
+
+
+class ListProposalsSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    value = serializers.FloatField(read_only=True)
+    scheduled_datetime = serializers.DateTimeField(read_only=True)
+    client = SimpleClientSerializer(read_only=True)
+    services = serializers.ListField(child=SimplesServiceSerializer(), read_only=True)
+    confirmed = serializers.BooleanField(read_only=True)
+
+
 class ProposalSerializer(serializers.Serializer):
     id = serializers.IntegerField(read_only=True)
     value = serializers.FloatField()

--- a/apps/interface_adapters/api/v1/views/professional_proposals_views.py
+++ b/apps/interface_adapters/api/v1/views/professional_proposals_views.py
@@ -6,11 +6,12 @@ from rest_framework_simplejwt.authentication import JWTAuthentication
 
 from apps.domain.exceptions.proposal_exceptions import ProposalException
 from apps.domain.usecases.create_proposal_use_case import CreateProposalUseCase
+from apps.domain.usecases.list_professional_proposals_use_case import ListProfessionalProposalsUseCase
 from apps.infrastructure.repositories.django_client_repository import DjangoClientRepository
 from apps.infrastructure.repositories.django_professional_repository import DjangoProfessionalRepository
 from apps.infrastructure.repositories.django_proposal_repository import DjangoProposalRepository
 from apps.infrastructure.repositories.django_service_repository import DjangoServiceRepository
-from apps.interface_adapters.api.v1.serializers.proposal_serializer import ProposalSerializer
+from apps.interface_adapters.api.v1.serializers.proposal_serializer import ListProposalsSerializer, ProposalSerializer
 
 
 class ProfessionalProposalView(APIView):
@@ -40,3 +41,14 @@ class ProfessionalProposalView(APIView):
             )
 
         return Response(None, status=status.HTTP_201_CREATED)
+
+    def get(self, request):
+        professional_id = request.user.id
+        use_case = ListProfessionalProposalsUseCase(
+            proposal_repository=DjangoProposalRepository(),
+            professional_repository=DjangoProfessionalRepository(),
+        )
+        proposals = use_case.list_all(professional_id)
+
+        serializer = ListProposalsSerializer(proposals, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/tests/api/v1/test_professional_proposals_views.py
+++ b/tests/api/v1/test_professional_proposals_views.py
@@ -4,7 +4,14 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
-from apps.infrastructure.models import CategoryModel, ClientModel, ProfessionalModel, ProposalModel, ServiceModel
+from apps.infrastructure.models import (
+    CategoryModel,
+    ClientModel,
+    ProfessionalModel,
+    ProposalModel,
+    ProposalServiceModel,
+    ServiceModel,
+)
 
 
 class ProfessionalProposalsViewTests(APITestCase):
@@ -49,3 +56,27 @@ class ProfessionalProposalsViewTests(APITestCase):
             },
         )
         self.assertFalse(ProposalModel.objects.filter(client=self.client_model, professional=self.professional))
+
+    def test_list_professional_proposals_success(self):
+        # Cria uma proposta para o profissional autenticado
+        proposal = ProposalModel.objects.create(
+            client=self.client_model,
+            professional=self.professional,
+            value=150.0,
+            scheduled_datetime=datetime(2025, 7, 12, 10, 0, 0),
+        )
+        ProposalServiceModel.objects.create(
+            proposal=proposal,
+            service=self.service,
+        )
+        response = self.api_client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["value"], 150.0)
+        self.assertEqual(response.data[0]["scheduled_datetime"], "2025-07-12T10:00:00Z")
+        self.assertEqual(response.data[0]["services"][0]["description"], "Corte Feminino")
+
+    def test_list_professional_proposals_empty(self):
+        response = self.api_client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 0)

--- a/tests/integration/usecases/test_list_professional_proposals_use_case.py
+++ b/tests/integration/usecases/test_list_professional_proposals_use_case.py
@@ -1,0 +1,52 @@
+from datetime import datetime, timezone
+
+from django.test import TestCase
+
+from apps.domain.usecases.list_professional_proposals_use_case import ListProfessionalProposalsUseCase
+from apps.infrastructure.models import (
+    CategoryModel,
+    ClientModel,
+    ProfessionalModel,
+    ProposalModel,
+    ProposalServiceModel,
+    ServiceModel,
+)
+from apps.infrastructure.repositories.django_professional_repository import DjangoProfessionalRepository
+from apps.infrastructure.repositories.django_proposal_repository import DjangoProposalRepository
+
+
+class ListProfessionalProposalsUseCaseIntegrationTest(TestCase):
+    def setUp(self):
+        self.category = CategoryModel.objects.create(description="Beleza")
+        self.service = ServiceModel.objects.create(category=self.category, description="Corte Feminino")
+        self.client_user = ClientModel.objects.create_user(
+            id="1",
+            username="cliente@ifrn.com.br",
+            email="cliente@ifrn.com.br",
+            password="senha123",
+            first_name="Cliente",
+            last_name="Teste",
+        )
+        self.professional = ProfessionalModel.objects.create(client=self.client_user)
+        self.proposal = ProposalModel.objects.create(
+            client=self.client_user,
+            professional=self.professional,
+            value=100.0,
+            scheduled_datetime=datetime(2025, 7, 12, 10, 0, 0),
+        )
+        ProposalServiceModel.objects.create(
+            proposal=self.proposal,
+            service=self.service,
+        )
+        self.proposal_repository = DjangoProposalRepository()
+        self.professional_repository = DjangoProfessionalRepository()
+        self.use_case = ListProfessionalProposalsUseCase(self.proposal_repository, self.professional_repository)
+
+    def test_list_professional_proposals(self):
+        proposals = self.use_case.list_all(self.professional.id)
+        self.assertEqual(len(proposals), 1)
+        proposal = proposals[0]
+        self.assertEqual(proposal.professional.id, self.professional.id)
+        self.assertEqual(proposal.value, 100.0)
+        self.assertEqual(proposal.scheduled_datetime, datetime(2025, 7, 12, 10, 0, 0, tzinfo=timezone.utc))
+        self.assertEqual(proposal.services[0].description, "Corte Feminino")

--- a/tests/unit/usecases/test_list_professional_proposals_use_case.py
+++ b/tests/unit/usecases/test_list_professional_proposals_use_case.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest.mock import MagicMock
+
+from apps.domain.entities.proposal import Proposal
+from apps.domain.usecases.list_professional_proposals_use_case import ListProfessionalProposalsUseCase
+
+
+class TestListProfessionalProposalsUseCase(unittest.TestCase):
+    def test_list_professional_proposals_returns_all(self):
+        mock_proposal_repository = MagicMock()
+        mock_professional_repository = MagicMock()
+        proposals = [
+            Proposal(
+                id=1,
+                client=MagicMock(id=1),
+                professional=MagicMock(id=2),
+                services=[],
+                value=100.0,
+                scheduled_datetime="2025-07-12T10:00:00Z",
+            ),
+            Proposal(
+                id=2,
+                client=MagicMock(id=3),
+                professional=MagicMock(id=2),
+                services=[],
+                value=200.0,
+                scheduled_datetime="2025-07-13T10:00:00Z",
+            ),
+        ]
+        mock_professional_repository.get_by_id.return_value = MagicMock(id=10)
+        mock_proposal_repository.list_proposals_by_professional.return_value = proposals
+        use_case = ListProfessionalProposalsUseCase(mock_proposal_repository, mock_professional_repository)
+        result = use_case.list_all(2)
+        self.assertEqual(result, proposals)
+        mock_professional_repository.get_by_id.assert_called_once_with(2)
+        mock_proposal_repository.list_proposals_by_professional.assert_called_once_with(10)


### PR DESCRIPTION
This pull request introduces functionality for listing proposals associated with a professional. It includes updates to repositories, serializers, views, and tests to support this feature. The most important changes are grouped below by theme.

### Repository Updates:
* Added the `list_proposals_by_professional` method to the `ProposalRepository` interface, allowing retrieval of proposals by professional ID. (`apps/domain/interfaces/repositories/proposal_repository.py`)
* Implemented the `list_proposals_by_professional` method in `DjangoProposalRepository`, mapping database models to domain entities. (`apps/infrastructure/repositories/django_proposal_repository.py`)

### Use Case Implementation:
* Created the `ListProfessionalProposalsUseCase` class, encapsulating the business logic to fetch all proposals for a professional. (`apps/domain/usecases/list_professional_proposals_use_case.py`)

### API Enhancements:
* Updated `ProfessionalProposalView` to handle `GET` requests, using the new use case to fetch proposals and serialize them for API responses. (`apps/interface_adapters/api/v1/views/professional_proposals_views.py`)
* Added `ListProposalsSerializer` to format proposal data for API responses, including nested serializers for clients and services. (`apps/interface_adapters/api/v1/serializers/proposal_serializer.py`)

### Testing:
* Added unit tests for `ListProfessionalProposalsUseCase` to validate its behavior with mocked repositories. (`tests/unit/usecases/test_list_professional_proposals_use_case.py`)
* Added integration tests for the use case to ensure proper interaction with the database. (`tests/integration/usecases/test_list_professional_proposals_use_case.py`)
* Enhanced API tests to cover successful and empty responses for listing professional proposals. (`tests/api/v1/test_professional_proposals_views.py`)