### PR TITLE
[DOCS] - Swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,15 +55,16 @@ python manage.py runserver
 
 ## Rodando os testes
 
---- # WIP
+Para executar os testes, certifique-se de que o ambiente virtual esteja ativado, todas as dependências instaladas e as migrações aplicadas ao banco de dados. Em seguida, execute o comando abaixo:
 
----
+```bash
+make test
+```
 
 ## Documentação da API
 
---- # WIP
-
----
+Para acessar as documentações, basta acessar no navegador: 
+[http://localhost:8000/docs/](http://localhost:8000/docs/)
 
 ## Observações futuras
 

--- a/apps/config/settings.py
+++ b/apps/config/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "apps.infrastructure",
     "apps.interface_adapters",
+    "drf_spectacular",
 ]
 
 MIDDLEWARE = [
@@ -134,4 +135,14 @@ MEDIA_URL = "/media/"
 SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(minutes=60),
     "REFRESH_TOKEN_LIFETIME": timedelta(days=7),
+}
+
+REST_FRAMEWORK = {
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+}
+
+SPECTACULAR_SETTINGS = {
+    "TITLE": "Ajeita Aqui API RESTful",
+    "DESCRIPTION": "Documentação da API",
+    "VERSION": "1.0.0",
 }

--- a/apps/config/urls.py
+++ b/apps/config/urls.py
@@ -19,8 +19,11 @@ from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("v1/", include("apps.interface_adapters.api.v1.urls")),
+    path("schema/", SpectacularAPIView.as_view(), name="schema"),
+    path("docs/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/apps/interface_adapters/api/v1/views/client_proposals_views.py
+++ b/apps/interface_adapters/api/v1/views/client_proposals_views.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -14,6 +15,7 @@ class ListClientProposalsView(APIView):
     authentication_classes = [JWTAuthentication]
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(parameters=None, responses={200: ListProposalsSerializer(many=True)})
     def get(self, request):
         client_id = request.user.id
         proposal_repository = DjangoProposalRepository()

--- a/apps/interface_adapters/api/v1/views/create_client_view.py
+++ b/apps/interface_adapters/api/v1/views/create_client_view.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -9,6 +10,14 @@ from apps.interface_adapters.api.v1.serializers.client_serializer import ClientS
 
 
 class CreateClientView(APIView):
+    @extend_schema(
+        request=ClientSerializer,
+        responses={
+            201: {"message": "Client created successfully"},
+            409: {"message": "error"},
+            400: {"message": "Invalid data"},
+        },
+    )
     def post(self, request, *args, **kwargs):
         serializer = ClientSerializer(data=request.data)
 

--- a/apps/interface_adapters/api/v1/views/create_professional_view.py
+++ b/apps/interface_adapters/api/v1/views/create_professional_view.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -13,6 +14,10 @@ class CreateProfessionalView(APIView):
     authentication_classes = [JWTAuthentication]
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(
+        request=None,
+        responses={201: {"message": "Professional created successfully"}, 400: {"message": "Invalid data"}},
+    )
     def post(self, request):
         client_id = request.user.id
 

--- a/apps/interface_adapters/api/v1/views/detail_client_view.py
+++ b/apps/interface_adapters/api/v1/views/detail_client_view.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -13,6 +14,10 @@ class DetailClientView(APIView):
     authentication_classes = [JWTAuthentication]
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(
+        request=None,
+        responses={200: ClientSerializer, 404: {"message": "Not found"}},
+    )
     def get(self, request, client_id):
         client_repository = DjangoClientRepository()
         use_case = DetailClientUseCase(client_repository)

--- a/apps/interface_adapters/api/v1/views/list_categories_views.py
+++ b/apps/interface_adapters/api/v1/views/list_categories_views.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -8,6 +9,10 @@ from apps.interface_adapters.api.v1.serializers.category_serializer import Categ
 
 
 class ListCategoriesView(APIView):
+    @extend_schema(
+        request=None,
+        responses={200: CategorySerializer},
+    )
     def get(self, request):
         use_case = ListCategoriesUseCase(DjangoCategoryRepository())
         categories = use_case.list_categories()

--- a/apps/interface_adapters/api/v1/views/list_portfolios_view.py
+++ b/apps/interface_adapters/api/v1/views/list_portfolios_view.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -8,6 +9,10 @@ from apps.interface_adapters.api.v1.serializers.portfolio_serializer import Port
 
 
 class ListPortfoliosView(APIView):
+    @extend_schema(
+        request=None,
+        responses={200: PortfolioDetailSerializer},
+    )
     def get(self, request):
         use_case = ListPortfoliosUseCase(DjangoPortfolioRepository())
         portfolios = use_case.list_portfolios()

--- a/apps/interface_adapters/api/v1/views/manage_portfolio_views.py
+++ b/apps/interface_adapters/api/v1/views/manage_portfolio_views.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -15,6 +16,10 @@ class ManagePortfolioViews(APIView):
     authentication_classes = [JWTAuthentication]
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(
+        request=PortfolioSerializer,
+        responses={201: {"message": "Portfolio created successfully"}, 400: {"message": "Invalid data"}},
+    )
     def post(self, request):
         client_id = request.user.id
 
@@ -44,6 +49,10 @@ class ManagePortfolioViews(APIView):
             status=status.HTTP_201_CREATED,
         )
 
+    @extend_schema(
+        request=PortfolioSerializer,
+        responses={200: {"message": "Portfolio updated successfully"}, 400: {"message": "Invalid data"}},
+    )
     def put(self, request):
         client_id = request.user.id
 

--- a/apps/interface_adapters/api/v1/views/manage_proposals_views.py
+++ b/apps/interface_adapters/api/v1/views/manage_proposals_views.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -16,6 +17,10 @@ class ManageProposalsView(APIView):
     authentication_classes = [JWTAuthentication]
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(
+        request=None,
+        responses={204: None, 400: {"error": "Bad Request"}},
+    )
     def delete(self, request, proposal_id):
         client_id = request.user.id
         proposal_repository = DjangoProposalRepository()
@@ -29,6 +34,10 @@ class ManageProposalsView(APIView):
 
         return Response(status=status.HTTP_204_NO_CONTENT)
 
+    @extend_schema(
+        request=None,
+        responses={200: PaymentSerializer, 400: {"error": "Bad Request"}},
+    )
     def post(self, request, proposal_id):
         client_id = request.user.id
         proposal_repository = DjangoProposalRepository()

--- a/apps/interface_adapters/api/v1/views/professional_proposals_views.py
+++ b/apps/interface_adapters/api/v1/views/professional_proposals_views.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -18,6 +19,10 @@ class ProfessionalProposalView(APIView):
     authentication_classes = [JWTAuthentication]
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(
+        request=ProposalSerializer,
+        responses={201: {"message": "Proposal created successfully"}, 400: {"message": "Invalid data"}},
+    )
     def post(self, request):
         request.data["professional_id"] = request.user.id
         serializer = ProposalSerializer(data=request.data)
@@ -42,6 +47,10 @@ class ProfessionalProposalView(APIView):
 
         return Response(None, status=status.HTTP_201_CREATED)
 
+    @extend_schema(
+        request=None,
+        responses={200: ListProposalsSerializer(many=True)},
+    )
     def get(self, request):
         professional_id = request.user.id
         use_case = ListProfessionalProposalsUseCase(

--- a/apps/interface_adapters/api/v1/views/profile_client_view.py
+++ b/apps/interface_adapters/api/v1/views/profile_client_view.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -13,6 +14,14 @@ class ProfileClientView(APIView):
     authentication_classes = [JWTAuthentication]
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(
+        request=ClientSerializer,
+        responses={
+            200: {"message": "Client updated successfully"},
+            400: {"message": "Invalid data"},
+            409: {"message": "Conflict"},
+        },
+    )
     def put(self, request):
         client_id = request.user.id
         serializer = ClientSerializer(data=request.data)

--- a/apps/interface_adapters/api/v1/views/search_portfolios_views.py
+++ b/apps/interface_adapters/api/v1/views/search_portfolios_views.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
@@ -9,6 +10,25 @@ from apps.interface_adapters.api.v1.serializers.portfolio_serializer import Port
 
 
 class SearchPortfolioView(APIView):
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="q", type=str, location=OpenApiParameter.QUERY, required=True, description="Texto da busca"
+            ),
+            OpenApiParameter(
+                name="type",
+                type=str,
+                location=OpenApiParameter.QUERY,
+                required=True,
+                description="Tipo da busca: 'service' ou 'professional'",
+                enum=["service", "professional"],
+            ),
+        ],
+        responses={
+            200: PortfolioDetailSerializer(many=True),
+            400: {"message": "Invalid data"},
+        },
+    )
     def get(self, request):
         query = request.query_params.get("q")
         search_type = request.query_params.get("type")  # 'service' ou 'professional'

--- a/apps/interface_adapters/api/v1/views/search_views.py
+++ b/apps/interface_adapters/api/v1/views/search_views.py
@@ -1,3 +1,4 @@
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
@@ -9,6 +10,25 @@ from apps.interface_adapters.api.v1.serializers.portfolio_serializer import Port
 
 
 class SearchPortfolioView(APIView):
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="q", type=str, location=OpenApiParameter.QUERY, required=True, description="Texto da busca"
+            ),
+            OpenApiParameter(
+                name="type",
+                type=str,
+                location=OpenApiParameter.QUERY,
+                required=True,
+                description="Tipo da busca: 'service' ou 'professional'",
+                enum=["service", "professional"],
+            ),
+        ],
+        responses={
+            200: PortfolioDetailSerializer(many=True),
+            400: {"message": "Invalid data"},
+        },
+    )
     def get(self, request):
         query = request.query_params.get("q")
         search_type = request.query_params.get("type")  # 'service' ou 'professional'

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ PyJWT==2.9.0
 sqlparse==0.5.3
 coverage==7.9.2
 unimport==1.2.1
+drf-spectacular==0.28.0
+drf-yasg==1.21.10


### PR DESCRIPTION
This pull request introduces API documentation using `drf-spectacular` and enhances the endpoints with detailed schema definitions. Key changes include the addition of the `drf-spectacular` library, configuration updates to support schema generation, and the application of `@extend_schema` decorators to document various API views.

### API Documentation Integration:
* **Library Addition**: Added `drf-spectacular` to the `INSTALLED_APPS` in `apps/config/settings.py`.
* **Settings Configuration**: Configured `REST_FRAMEWORK` to use `drf-spectacular.openapi.AutoSchema` and added `SPECTACULAR_SETTINGS` for API metadata such as title, description, and version.
* **Schema and Swagger UI Endpoints**: Added `/schema/` and `/docs/` endpoints to `apps/config/urls.py` for schema generation and Swagger UI access.

### Endpoint Enhancements:
* **General Endpoint Documentation**: Applied `@extend_schema` decorators to various API views, specifying request parameters, response formats, and status codes. Examples include `ListClientProposalsView`, `CreateClientView`, and `ManagePortfolioViews` for better clarity and developer usability. [[1]](diffhunk://#diff-a82a139a7179cfce205458d23a63d9228a0d26fcbd35cc36c9e022673d8a9f80R18) [[2]](diffhunk://#diff-bfad1a4cd8fa4d4dd12fa15a128d644d35c04e71e8a2ea77058b35b971f23f62R13-R20) [[3]](diffhunk://#diff-f3840b14e3ce1b2c43c7ae3a2198797c264bfcc1e6997c80886ad0b87d9e59c7R52-R55)
* **Search Functionality**: Enhanced search views (`SearchPortfolioView` and `SearchViews`) with detailed query parameter definitions using `OpenApiParameter`. This includes specifying required fields and enumerated values for search types. [[1]](diffhunk://#diff-90b7702b6a3d3f094346e89c9967af285182aeb0c39b3bbde824bc681b23026eR1) [[2]](diffhunk://#diff-90b7702b6a3d3f094346e89c9967af285182aeb0c39b3bbde824bc681b23026eR13-R31)

### README Update:
* **Testing Instructions**: Updated the README to include clear instructions for running tests using `make test`.
* **API Documentation Access**: Added information on accessing API documentation via the `/docs/` endpoint.